### PR TITLE
Conquest: Engine: Console: Add erase in line (CSI K) command

### DIFF
--- a/src/conquest/engine/console/hook/CommandParser.h
+++ b/src/conquest/engine/console/hook/CommandParser.h
@@ -9,6 +9,7 @@
 #include "conquest/engine/console/hook/command/TextCommand.h"
 #include "conquest/engine/console/hook/command/ToggleCommand.h"
 #include "conquest/engine/console/hook/command/CursorCommand.h"
+#include "conquest/engine/console/hook/command/EraseCommand.h"
 #include "conquest/engine/console/hook/Commands.h"
 
 
@@ -47,7 +48,8 @@ using CommandCreator = detail::CommandsCreator<
     MoveCursorUpCommand,
     MoveCursorDownCommand,
     MoveCursorForwardCommand,
-    MoveCursorBackwardCommand
+    MoveCursorBackwardCommand,
+    EraseInLineCommand
 >;
 
 class CommandParser

--- a/src/conquest/engine/console/hook/TextWriter.cpp
+++ b/src/conquest/engine/console/hook/TextWriter.cpp
@@ -34,6 +34,33 @@ void TextWriter::write(const SpriteMapper::SpriteIndex_t character)
 	m_Screen.setGlyph(m_Cursor.x, m_Cursor.y, { m_SpriteMapper.fetch(character), m_Foreground, m_Background });
 }
 
+void TextWriter::eraseInLine(const EraseMode mode)
+{
+	if(m_Cursor.y >= m_Screen.height()) {
+		return;
+	}
+
+	const auto blankGlyph = Glyph{ m_SpriteMapper.fetch(' '), DEFAULT_FOREGROUND, DEFAULT_BACKGROUND };
+
+	size_t start = 0;
+	size_t end = m_Screen.width();
+
+	switch(mode) {
+	case EraseMode::CursorToEnd:
+		start = m_Cursor.x;
+		break;
+	case EraseMode::StartToCursor:
+		end = m_Cursor.x + 1;
+		break;
+	case EraseMode::EntireLine:
+		break;
+	}
+
+	for(size_t x = start; x < end; ++x) {
+		m_Screen.setGlyph(x, m_Cursor.y, blankGlyph);
+	}
+}
+
 void TextWriter::setForeground(const Color &color)
 {
 	m_Foreground = color;

--- a/src/conquest/engine/console/hook/TextWriter.h
+++ b/src/conquest/engine/console/hook/TextWriter.h
@@ -11,6 +11,13 @@ namespace conquest::engine::console {
 inline constexpr Color DEFAULT_FOREGROUND = { 255, 255, 255 };
 inline constexpr Color DEFAULT_BACKGROUND = { 0, 0, 0 };
 
+enum class EraseMode : uint32_t
+{
+	CursorToEnd = 0,
+	StartToCursor = 1,
+	EntireLine = 2,
+};
+
 class TextWriter
 {
 public:
@@ -27,6 +34,11 @@ public:
 	void carriageReturn();
 
 	void write(SpriteMapper::SpriteIndex_t character);
+
+	/**
+		Erases part of the current line.
+	 */
+	void eraseInLine(EraseMode mode);
 
 	void setForeground(const Color& color);
 	void setBackground(const Color& color);

--- a/src/conquest/engine/console/hook/command/EraseCommand.cpp
+++ b/src/conquest/engine/console/hook/command/EraseCommand.cpp
@@ -1,0 +1,14 @@
+#include "conquest/engine/console/hook/command/EraseCommand.h"
+
+
+namespace conquest::engine::console {
+
+void EraseInLineCommand::execute(std::istringstream& stream, TextWriter& writer)
+{
+	uint32_t mode = 0;
+	stream >> mode;
+
+	writer.eraseInLine(static_cast<EraseMode>(mode));
+}
+
+}

--- a/src/conquest/engine/console/hook/command/EraseCommand.h
+++ b/src/conquest/engine/console/hook/command/EraseCommand.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "conquest/engine/console/hook/Commands.h"
+
+
+namespace conquest::engine::console {
+
+class EraseInLineCommand final : public CommandBase<'K', EraseInLineCommand>
+{
+public:
+	static void execute(std::istringstream& stream, TextWriter& writer);
+};
+
+}


### PR DESCRIPTION
Adds support for the ESC[xK (Erase in Line) CSI escape sequence.

## Changes
- Added EraseInLineCommand class handling the K CSI command identifier
- Added eraseInLine method to TextWriter supporting all three modes:
  - 0 (default): Clear from cursor to end of line
  - 1: Clear from start of line to cursor
  - 2: Clear entire line
- Registered the new command in CommandCreator